### PR TITLE
Autowireable entity repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,20 +97,44 @@ The `cache` key determines if the obtained OAuth token should be cached. If set 
 
 ### CRUD Repository
 
-Shopware provides the usual CRUD operations for entities. The bundle provides repositories to execute this operations. Currently, the repositories cannot be autowired directly. They have to be obtained via the `RepositoryProviderInterface`.
+Shopware provides the usual CRUD operations for entities. The bundle provides repositories to execute this operations. 
+
+The repositories can injected directly via autowiring:
+
+```php
+use Vin\ShopwareSdk\Repository\RepositoryInterface;
+
+final class ProductService {
+    public function __construct(
+        private RepositoryInterface $productEntityRepository,
+        private RepositoryInterface $orderTransactionCaptureRefundPositionEntityRepository,
+    ) {
+    }
+    
+    // ...
+}
+```
+
+The dependency injection container will automatically will let the `RepositoryProvider` create the requested repositories based on the argument name.
+The argument name has to be the entity name in camel case with the suffix `EntityRepository`. The `RepositoryInterface` type hint is required.
+
+Alternatively, they can be obtained via the `RepositoryProviderInterface`.
 
 ```php
 use Vin\ShopwareSdk\Repository\RepositoryProviderInterface;
 use Vin\ShopwareSdk\Repository\RepositoryInterface;
 use Vin\ShopwareSdk\Data\Entity\v65812\Product\ProductDefinition;
+use Vin\ShopwareSdk\Data\Entity\v65812\OrderTransactionCaptureRefundPosition\OrderTransactionCaptureRefundPositionDefinition
 
 final class ProductService {
     private RepositoryInterface $productRepository;
+    private RepositoryInterface $orderTransactionCaptureRefundPositionRepository;
 
     public function __construct(
         RepositoryProviderInterface $repositoryProvider
     ) {
         $this->productRepository = $repositoryProvider->getRepository(ProductDefinition::ENTITY_NAME);
+        $this->orderTransactionCaptureRefundPositionRepository = $repositoryProvider->getRepository(OrderTransactionCaptureRefundPositionDefinition::ENTITY_NAME);
     }
     
     // ...

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "it-bens/shopware-sdk": "^0.3",
+        "it-bens/shopware-sdk": "^0.4",
         "symfony/config": "^6.4|^7.1",
         "symfony/dependency-injection": "^6.4|^7.1",
         "symfony/http-kernel": "^6.4|^7.1"

--- a/src/DependencyInjection/Compiler/MakeEntityRepositoriesAutowirableCompilerPass.php
+++ b/src/DependencyInjection/Compiler/MakeEntityRepositoriesAutowirableCompilerPass.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareSdkBundle\DependencyInjection\Compiler;
+
+use ITB\ShopwareSdkBundle\DependencyInjection\Constant\Tags;
+use ITB\ShopwareSdkBundle\DependencyInjection\ITBShopwareSdkExtension;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
+use Vin\ShopwareSdk\Repository\EntityRepository;
+use Vin\ShopwareSdk\Repository\RepositoryInterface;
+use Vin\ShopwareSdk\Repository\RepositoryProviderInterface;
+
+final class MakeEntityRepositoriesAutowirableCompilerPass implements CompilerPassInterface
+{
+    private const ENTITY_REPOSITORY_ID = 'itb_shopware_sdk.repository.%s_entity_repository';
+
+    private const ENTITY_REPOSITORY_ARGUMENT_NAME = '%s_entity_repository';
+
+    public function __construct(
+        private readonly ITBShopwareSdkExtension $extension
+    ) {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $configs = $container->getExtensionConfig(ITBShopwareSdkExtension::ALIAS);
+        $config = $this->extension->getConfig($configs, $container);
+
+        $shopwareVersion = $config['shopware_version'];
+
+        $entityNameSets = [];
+        foreach ($container->findTaggedServiceIds(Tags::ENTITY_DEFINITION_COLLECTION_POPULATOR) as $id => $tags) {
+            $definition = $container->getDefinition($id);
+            $class = $definition->getClass();
+            $reflection = $container->getReflectionClass($class, false);
+            if (! $reflection instanceof \ReflectionClass) {
+                continue;
+            }
+
+            if ($reflection->implementsInterface(DefinitionCollectionPopulator::class) === false) {
+                continue;
+            }
+            /** @var class-string<DefinitionCollectionPopulator> $class */
+
+            $entityNameSets[] = [
+                'entityNames' => $class::getEntityNames($shopwareVersion),
+                'priority' => $class::priority(),
+            ];
+        }
+
+        usort($entityNameSets, fn ($a, $b) => $b['priority'] <=> $a['priority']);
+        /** @var string[] $entityNames */
+        $entityNames = array_merge(...array_column($entityNameSets, 'entityNames'));
+
+        foreach ($entityNames as $entityName) {
+            $id = sprintf(self::ENTITY_REPOSITORY_ID, $entityName);
+            $argumentName = sprintf(self::ENTITY_REPOSITORY_ARGUMENT_NAME, $entityName);
+
+            $entityRepositoryDefinition = new Definition(EntityRepository::class);
+            $entityRepositoryDefinition->setFactory([new Reference(RepositoryProviderInterface::class), 'getRepository']);
+            $entityRepositoryDefinition->setArguments([$entityName]);
+            $entityRepositoryDefinition->setPublic(false);
+
+            $container->setDefinition($id, $entityRepositoryDefinition);
+            $container->registerAliasForArgument($id, RepositoryInterface::class, $argumentName);
+        }
+    }
+}

--- a/src/DependencyInjection/ITBShopwareSdkExtension.php
+++ b/src/DependencyInjection/ITBShopwareSdkExtension.php
@@ -30,15 +30,27 @@ final class ITBShopwareSdkExtension extends Extension
         return self::ALIAS;
     }
 
+    /**
+     * @param array<array<mixed>> $configs
+     * @return ITBShopwareSdkConfiguration
+     */
+    public function getConfig(array $configs, ContainerBuilder $container): array
+    {
+        /** @var ConfigurationInterface $configuration */
+        $configuration = $this->getConfiguration($configs, $container);
+        /** @var ITBShopwareSdkConfiguration $config */
+        $config = $this->processConfiguration($configuration, $configs);
+
+        return $config;
+    }
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.php');
 
-        /** @var ConfigurationInterface $configuration */
-        $configuration = $this->getConfiguration($configs, $container);
         /** @var ITBShopwareSdkConfiguration $config */
-        $config = $this->processConfiguration($configuration, $configs);
+        $config = $this->getConfig($configs, $container);
 
         $this->configureShopUrl($container, $config);
         $this->configureShopwareVersion($container, $config);

--- a/src/ITBShopwareSdkBundle.php
+++ b/src/ITBShopwareSdkBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ITB\ShopwareSdkBundle;
 
 use ITB\ShopwareSdkBundle\DependencyInjection\Compiler\EntityDefinitionCollectionPopulatorsCompilerPass;
+use ITB\ShopwareSdkBundle\DependencyInjection\Compiler\MakeEntityRepositoriesAutowirableCompilerPass;
 use ITB\ShopwareSdkBundle\DependencyInjection\ITBShopwareSdkExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -13,7 +14,10 @@ final class ITBShopwareSdkBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {
-        $container->addCompilerPass(new EntityDefinitionCollectionPopulatorsCompilerPass());
+        $extension = $this->getContainerExtension();
+
+        $container->addCompilerPass(new EntityDefinitionCollectionPopulatorsCompilerPass(), priority: 0);
+        $container->addCompilerPass(new MakeEntityRepositoriesAutowirableCompilerPass($extension), priority: -1);
     }
 
     public function getContainerExtension(): ITBShopwareSdkExtension

--- a/tests/Functional/Repository/EntityRepositoryTest.php
+++ b/tests/Functional/Repository/EntityRepositoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareSdkBundle\Tests\Functional\Repository;
+
+use ITB\ShopwareSdkBundle\DependencyInjection\Configuration;
+use ITB\ShopwareSdkBundle\Tests\ITBShopwareSdkBundleKernel;
+use ITB\ShopwareSdkBundle\Tests\Mock\AdditionalDefinitionCollectionPopulator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Yaml\Yaml;
+use Vin\ShopwareSdk\Definition\EntityDefinitionCollectionPopulator\WithSdkMapping;
+use Vin\ShopwareSdk\Repository\RepositoryInterface;
+
+/**
+ * @phpstan-import-type ITBShopwareSdkConfiguration from Configuration
+ */
+final class EntityRepositoryTest extends TestCase
+{
+    public static function provider(): \Generator
+    {
+        $config = Yaml::parseFile(__DIR__ . '/../../Fixtures/Configuration/config_with_enabled_cache.yaml');
+
+        $additionalDefinitionCollectionPopulatorDefinition = new Definition(AdditionalDefinitionCollectionPopulator::class);
+        $additionalDefinitionCollectionPopulatorDefinition->setPublic(false);
+
+        yield [
+            $config, [
+                AdditionalDefinitionCollectionPopulator::class => $additionalDefinitionCollectionPopulatorDefinition,
+            ]];
+    }
+
+    /**
+     * @param ITBShopwareSdkConfiguration $config
+     * @param array<string, Definition> $dependencyInjectionDefinitions
+     */
+    #[DataProvider('provider')]
+    public function testRegistration(array $config, array $dependencyInjectionDefinitions): void
+    {
+        $kernel = new ITBShopwareSdkBundleKernel('test', true, $config, $dependencyInjectionDefinitions);
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+
+        $shopwareVersion = $config['shopware_version'];
+        $entityNames = WithSdkMapping::getEntityNames($shopwareVersion);
+        $entityNames = array_merge($entityNames, AdditionalDefinitionCollectionPopulator::getEntityNames($shopwareVersion));
+        $this->assertNotEmpty($entityNames);
+
+        foreach ($entityNames as $entityName) {
+            $entityRepository = $container->get('itb_shopware_sdk.repository.' . $entityName . '_entity_repository');
+            $this->assertInstanceOf(RepositoryInterface::class, $entityRepository);
+            $this->assertSame($entityName, $entityRepository->getDefinition()->getEntityName());
+
+            $entityRepository = $container->get('.' . RepositoryInterface::class . ' $' . $entityName . '_entity_repository');
+            $this->assertInstanceOf(RepositoryInterface::class, $entityRepository);
+            $this->assertSame($entityName, $entityRepository->getDefinition()->getEntityName());
+        }
+    }
+}

--- a/tests/Mock/AdditionalDefinitionCollectionPopulator.php
+++ b/tests/Mock/AdditionalDefinitionCollectionPopulator.php
@@ -9,6 +9,11 @@ use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
 final class AdditionalDefinitionCollectionPopulator implements DefinitionCollectionPopulator
 {
+    public static function getEntityNames(string $shopwareVersion): array
+    {
+        return ['new_entity'];
+    }
+
     public static function priority(): int
     {
         return 1;

--- a/tests/Mock/AdditionalDefinitionCollectionPopulatorWithException.php
+++ b/tests/Mock/AdditionalDefinitionCollectionPopulatorWithException.php
@@ -9,6 +9,11 @@ use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
 final class AdditionalDefinitionCollectionPopulatorWithException implements DefinitionCollectionPopulator
 {
+    public static function getEntityNames(string $shopwareVersion): array
+    {
+        return [];
+    }
+
     public static function priority(): int
     {
         return 1;


### PR DESCRIPTION
Entity repositories could only be retrieved through the `RepositoryProvider` which takes care of the creation. 

The 0.4 version of the Shopware SDK added a static `getEntityNames` method to the `DefinitionCollectionPopulator` interface.
This PR adds a compiler pass that fetches all registered entity names by calling this static function. It creates and registers definitions for a repository for every entity (name). The repositories are furthermore aliased for argument usage.