### PR TITLE
Cache configuration with service ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ itb_shopware_sdk:
     grant_type: 'client_credentials'
     client_id: 'CLIENT_ID'
     client_secret: 'CLIENT_SECRET'
-  cache: true
+  cache: 'cache.app'
 ```
 
 The `shopware_version` key determines what entity schema is used for the native Shopware entities. Available versions are: `0.0.0.0`, `6.5.5.0`, `6.5.6.0`, `6.5.7.1`, `6.5.8.0`, `6.5.8.3`, `6.5.8.8`, `6.5.8.12`, `6.6.0.0`, `6.6.3.0`, `6.6.4.0`, `6.6.5.0`, `6.6.6.0` and `6.6.7.0`.
@@ -89,10 +89,10 @@ itb_shopware_sdk:
     grant_type: 'password'
     username: 'USERNAME'
     password: 'PASSWORD'
-  cache: true
+  cache: 'cache.app'
 ```
 
-The `cache` key determines if the obtained OAuth token should be cached. If set to `false` every request will request a new token from Shopware, first.
+The `cache` key determines if the obtained OAuth token should be cached. If set to `null` every request will request a new token from Shopware, before doing anything else.
 
 ## Usage
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ use Vin\ShopwareSdk\Auth\GrantType;
  *     shop_url: string,
  *     shopware_version: string,
  *     credentials: ClientCredentialsConfiguration|UsernamePasswordConfiguration,
- *     cache: bool
+ *     cache: string|null
  * }
  */
 final class Configuration implements ConfigurationInterface
@@ -87,9 +87,9 @@ final class Configuration implements ConfigurationInterface
                         )
                     ->end()
                 ->end()
-                ->booleanNode('cache')
-                    ->info('Enable or disable the cache for the Shopware access token. A new token will be requested on every request if the cache is disabled.')
-                    ->defaultTrue()
+                ->scalarNode('cache')
+                    ->info('The service ID of the cache that should be used for the Shopware access token. A new token will be requested on every request if no service ID is given.')
+                    ->defaultNull()
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/ITBShopwareSdkExtension.php
+++ b/src/DependencyInjection/ITBShopwareSdkExtension.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ITB\ShopwareSdkBundle\DependencyInjection;
 
 use ITB\ShopwareSdkBundle\DependencyInjection\Constant\ServiceIds;
-use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -101,7 +100,7 @@ final class ITBShopwareSdkExtension extends Extension
      */
     private function configureAccessTokenFetcher(ContainerBuilder $container, array $config): void
     {
-        if ($config['cache'] === false) {
+        if ($config['cache'] === null) {
             $container->removeDefinition(ServiceIds::CACHED_ACCESS_TOKEN_FETCHER);
             $container->setAlias(AccessTokenFetcher::class, ServiceIds::SIMPLE_ACCESS_TOKEN_FETCHER)->setPublic(true);
 
@@ -109,7 +108,7 @@ final class ITBShopwareSdkExtension extends Extension
         }
 
         $cachedAccessTokenFetcherDefinition = $container->getDefinition(ServiceIds::CACHED_ACCESS_TOKEN_FETCHER);
-        $cachedAccessTokenFetcherDefinition->setArgument('$cache', new Reference(CacheInterface::class));
+        $cachedAccessTokenFetcherDefinition->setArgument('$cache', new Reference($config['cache']));
 
         $container->setAlias(AccessTokenFetcher::class, ServiceIds::CACHED_ACCESS_TOKEN_FETCHER)->setPublic(true);
     }

--- a/tests/Compiler/PsrSimpleCacheServicesCompilerPass.php
+++ b/tests/Compiler/PsrSimpleCacheServicesCompilerPass.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ITB\ShopwareSdkBundle\Tests\Compiler;
 
-use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -23,8 +22,6 @@ final class PsrSimpleCacheServicesCompilerPass implements CompilerPassInterface
         $psr16Cache->setArguments([
             '$pool' => new Reference('test_cache'),
         ]);
-        $container->setDefinition('cache', $psr16Cache);
-
-        $container->setAlias(CacheInterface::class, 'cache');
+        $container->setDefinition('cache.app', $psr16Cache);
     }
 }

--- a/tests/Fixtures/Configuration/config_with_client_credentials.yaml
+++ b/tests/Fixtures/Configuration/config_with_client_credentials.yaml
@@ -4,4 +4,4 @@ credentials:
   grant_type: 'client_credentials'
   client_id: 'CLIENT_ID'
   client_secret: 'CLIENT_SECRET'
-cache: true
+cache: cache.app

--- a/tests/Fixtures/Configuration/config_with_disabled_cache.yaml
+++ b/tests/Fixtures/Configuration/config_with_disabled_cache.yaml
@@ -4,4 +4,4 @@ credentials:
   grant_type: 'client_credentials'
   client_id: 'CLIENT_ID'
   client_secret: 'CLIENT_SECRET'
-cache: false
+cache:

--- a/tests/Fixtures/Configuration/config_with_enabled_cache.yaml
+++ b/tests/Fixtures/Configuration/config_with_enabled_cache.yaml
@@ -4,4 +4,4 @@ credentials:
   grant_type: 'client_credentials'
   client_id: 'CLIENT_ID'
   client_secret: 'CLIENT_SECRET'
-cache: true
+cache: cache.app

--- a/tests/Fixtures/Configuration/config_with_username_password.yaml
+++ b/tests/Fixtures/Configuration/config_with_username_password.yaml
@@ -4,4 +4,4 @@ credentials:
   grant_type: 'password'
   username: 'USERNAME'
   password: 'PASSWORD'
-cache: true
+cache: cache.app


### PR DESCRIPTION
Until now, the cache, used for storing auth tokens, could be enabled and disabled. This PR changes this configuration value to a string that contains the service ID of a cache service. If the value is left or set to null, the cache will be disabled.