### PR TITLE
Prevention of credential configuration deep merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ itb_shopware_sdk:
   cache: 'cache.app'
 ```
 
+The `credentials` block will not be merged with other configuration files or environments to prevent `Environment variables ... are never used.` errors when different grant types are used in different environments. The block will be overwritten according to the hirarchy defined by Symfony: https://symfony.com/doc/current/configuration.html#configuration-environments.
+
 The `cache` key determines if the obtained OAuth token should be cached. If set to `null` every request will request a new token from Shopware, before doing anything else.
 
 ## Usage

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('credentials')
                     ->info('The credentials are used with the given grant type to authenticate against the Shopware API.')
                     ->isRequired()
+                    ->performNoDeepMerging()
                     ->children()
                         ->enumNode('grant_type')
                             ->isRequired()


### PR DESCRIPTION
Symfony merges configurations from several files for different environments to create a processable configuration for bundles to be processed. 

A typicale example is the usage of username and password in test environments but client credentials in production.

test environment:
```yaml
shop_url: 'https://shopware.local'
shopware_version: '6.5.5.0'
credentials:
  grant_type: 'password'
  username: '%env(SHOPWARE_USER)%'
  password: '%env(SHOPWARE_PASSWORD)%'
cache: cache.app
```

production environment:
```yaml
shop_url: 'https://shopware.local'
shopware_version: '6.5.5.0'
credentials:
  grant_type: 'client_credentials'
  client_id: '%env(SHOPWARE_CLIENT_ID)%'
  client_secret: '%env(SHOPWARE_CLIENT_SECRET)%'
cache: cache.app
```

There is a [mechanism](https://github.com/symfony/symfony/blob/91497dccae3ef32aba5c9e28e84a0bd6c9ddbfba/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php#L403) in Symfony that throws an exception if an environment variable is defined but not used.

The shown configuration would lead that excpetion in a test environment:
`Symfony\Component\DependencyInjection\Exception\EnvParameterException: Environment variables "SHOPWARE_CLIENT_ID", "SHOPWARE_CLIENT_SECRET" are never used. Please, check your container's configuration.`

This PR prevents the merging of the `credentials` block in the configuration.