### PR TITLE
Replacement of entity definition collection populators autotagging with registerAttributeForAutoconfiguration call

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,12 @@ New entities can be added to Shopware via Plugins. The SDK package and this bund
 This requires an implementation of the `DefinitionCollectionPopulator` interface.
 
 ```php
+use ITB\ShopwareSdkBundle\Attribute\AsEntityDefinitionCollectionPopulator;
 use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 use Vin\ShopwareSdk\Definition\DefinitionCollection;
 use Vin\ShopwareSdk\Data\Entity\EntityDefinition;
 
+#[AsEntityDefinitionCollectionPopulator]
 final class CustomDefinitionCollectionPopulator implements DefinitionCollectionPopulator {
     public static function getEntityNames(string $shopwareVersion): array
     {
@@ -293,7 +295,9 @@ final class CustomDefinitionCollectionPopulator implements DefinitionCollectionP
 }
 ```
 
-If the service is autowired a compiler pass in this bundle will detect the interface usage, tag the service an add it to the `DefinitionCollectionProvider`.
+If the service has the `AsEntityDefinitionCollectionPopulator` attribute and is marked for autoconfiguration (this will likely happen in a typical Symfony project), the service is automatically tagged as a `DefinitionCollectionPopulator`.
+
+After that a compiler pass in this bundle will detect the tag and add the service to the `DefinitionCollectionProvider`.
 Of cause the service can be tagged manually as well:
 
 ```php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,13 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:enumNode\\(\\)\\.$#"
+			message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\:\:enumNode\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/DependencyInjection/Configuration.php
+
+		-
+			message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\) expects callable\(Symfony\\Component\\DependencyInjection\\ChildDefinition, ITB\\ShopwareSdkBundle\\Attribute\\AsEntityDefinitionCollectionPopulator, Reflector\)\: void, Closure\(Symfony\\Component\\DependencyInjection\\ChildDefinition, ITB\\ShopwareSdkBundle\\Attribute\\AsEntityDefinitionCollectionPopulator, ReflectionClass\)\: void given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DependencyInjection/ITBShopwareSdkExtension.php

--- a/src/Attribute/AsEntityDefinitionCollectionPopulator.php
+++ b/src/Attribute/AsEntityDefinitionCollectionPopulator.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareSdkBundle\Attribute;
+
+/**
+ * Service tag to autoconfigure entity definition populators.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class AsEntityDefinitionCollectionPopulator
+{
+}

--- a/src/DependencyInjection/Compiler/EntityDefinitionCollectionPopulatorsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/EntityDefinitionCollectionPopulatorsCompilerPass.php
@@ -9,24 +9,11 @@ use ITB\ShopwareSdkBundle\DependencyInjection\Constant\Tags;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
 final class EntityDefinitionCollectionPopulatorsCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        foreach ($container->getDefinitions() as $id => $definition) {
-            $reflection = $container->getReflectionClass($definition->getClass(), false);
-            if (! $reflection instanceof \ReflectionClass) {
-                continue;
-            }
-
-            if ($reflection->implementsInterface(DefinitionCollectionPopulator::class)) {
-                $definition->addTag(Tags::ENTITY_DEFINITION_COLLECTION_POPULATOR);
-                $container->setDefinition($id, $definition);
-            }
-        }
-
         $entityDefinitionProviderDefinition = $container->getDefinition(ServiceIds::ENTITY_DEFINITION_PROVIDER);
         $entityDefinitionProviderDefinition->setArgument(
             '$definitionCollectionPopulators',

--- a/src/DependencyInjection/ITBShopwareSdkExtension.php
+++ b/src/DependencyInjection/ITBShopwareSdkExtension.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace ITB\ShopwareSdkBundle\DependencyInjection;
 
+use ITB\ShopwareSdkBundle\Attribute\AsEntityDefinitionCollectionPopulator;
 use ITB\ShopwareSdkBundle\DependencyInjection\Constant\ServiceIds;
+use ITB\ShopwareSdkBundle\DependencyInjection\Constant\Tags;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -55,6 +58,7 @@ final class ITBShopwareSdkExtension extends Extension
         $this->configureShopwareVersion($container, $config);
         $this->configureAccessTokenFetcher($container, $config);
         $this->configureAccessTokenProvider($container, $config);
+        $this->configureEntityDefinitionCollectionPopulators($container);
     }
 
     /**
@@ -132,5 +136,15 @@ final class ITBShopwareSdkExtension extends Extension
 
         $contextBuilderFactoryDefinition = $container->getDefinition(ServiceIds::CONTEXT_BUILDER_FACTORY);
         $contextBuilderFactoryDefinition->setArgument('$shopUrl', $config['shop_url']);
+    }
+
+    private function configureEntityDefinitionCollectionPopulators(ContainerBuilder $container): void
+    {
+        $container->registerAttributeForAutoconfiguration(
+            AsEntityDefinitionCollectionPopulator::class,
+            static function (ChildDefinition $definition): void {
+                $definition->addTag(Tags::ENTITY_DEFINITION_COLLECTION_POPULATOR);
+            }
+        );
     }
 }

--- a/src/DependencyInjection/ITBShopwareSdkExtension.php
+++ b/src/DependencyInjection/ITBShopwareSdkExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Vin\ShopwareSdk\Auth\AccessTokenFetcher;
 use Vin\ShopwareSdk\Auth\AccessTokenProvider;
 use Vin\ShopwareSdk\Auth\GrantType;
+use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
 /**
  * @phpstan-import-type ITBShopwareSdkConfiguration from Configuration
@@ -142,7 +143,19 @@ final class ITBShopwareSdkExtension extends Extension
     {
         $container->registerAttributeForAutoconfiguration(
             AsEntityDefinitionCollectionPopulator::class,
-            static function (ChildDefinition $definition): void {
+            static function (
+                ChildDefinition $definition,
+                AsEntityDefinitionCollectionPopulator $attribute,
+                \ReflectionClass $reflector
+            ): void {
+                if (! $reflector->implementsInterface(DefinitionCollectionPopulator::class)) {
+                    throw new \RuntimeException(sprintf(
+                        'The class %s must implement %s to be used as an entity definition collection populator. The `AsEntityDefinitionCollectionPopulator` attribute cannot be used here.',
+                        $reflector->getName(),
+                        DefinitionCollectionPopulator::class
+                    ));
+                }
+
                 $definition->addTag(Tags::ENTITY_DEFINITION_COLLECTION_POPULATOR);
             }
         );

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use ITB\ShopwareSdkBundle\DependencyInjection\Constant\ServiceIds;
+use ITB\ShopwareSdkBundle\DependencyInjection\Constant\Tags;
 use Psr\Clock\ClockInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface as PsrRequestFactoryInterface;
@@ -114,6 +115,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->public();
 
     $services->set(ServiceIds::ENTITY_DEFINITION_COLLECTION_POPULATOR_WITH_SDK_MAPPING, WithSdkMapping::class)
+        ->tag(Tags::ENTITY_DEFINITION_COLLECTION_POPULATOR)
         ->private();
 
     $services->set(ServiceIds::ENTITY_DEFINITION_PROVIDER, DefinitionProvider::class)

--- a/tests/Functional/Definition/DefinitionProviderTest.php
+++ b/tests/Functional/Definition/DefinitionProviderTest.php
@@ -26,6 +26,7 @@ final class DefinitionProviderTest extends TestCase
         $config = Yaml::parseFile(__DIR__ . '/../../Fixtures/Configuration/config_with_enabled_cache.yaml');
 
         $additionalDefinitionCollectionPopulatorDefinition = new Definition(AdditionalDefinitionCollectionPopulatorWithException::class);
+        $additionalDefinitionCollectionPopulatorDefinition->setAutoconfigured(true);
         $additionalDefinitionCollectionPopulatorDefinition->setPublic(false);
 
         yield [
@@ -39,6 +40,7 @@ final class DefinitionProviderTest extends TestCase
         $config = Yaml::parseFile(__DIR__ . '/../../Fixtures/Configuration/config_with_enabled_cache.yaml');
 
         $additionalDefinitionCollectionPopulatorDefinition = new Definition(AdditionalDefinitionCollectionPopulator::class);
+        $additionalDefinitionCollectionPopulatorDefinition->setAutoconfigured(true);
         $additionalDefinitionCollectionPopulatorDefinition->setPublic(false);
 
         yield [

--- a/tests/Functional/Definition/DefinitionProviderTest.php
+++ b/tests/Functional/Definition/DefinitionProviderTest.php
@@ -7,12 +7,14 @@ namespace ITB\ShopwareSdkBundle\Tests\Functional\Definition;
 use ITB\ShopwareSdkBundle\DependencyInjection\Configuration;
 use ITB\ShopwareSdkBundle\Tests\ITBShopwareSdkBundleKernel;
 use ITB\ShopwareSdkBundle\Tests\Mock\AdditionalDefinitionCollectionPopulator;
+use ITB\ShopwareSdkBundle\Tests\Mock\AdditionalDefinitionCollectionPopulatorNotImplementingInterface;
 use ITB\ShopwareSdkBundle\Tests\Mock\AdditionalDefinitionCollectionPopulatorWithException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Yaml\Yaml;
 use Vin\ShopwareSdk\Definition\DefinitionCollection;
+use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 use Vin\ShopwareSdk\Definition\DefinitionProvider;
 use Vin\ShopwareSdk\Definition\DefinitionProviderInterface;
 
@@ -46,6 +48,22 @@ final class DefinitionProviderTest extends TestCase
         yield [
             $config, [
                 AdditionalDefinitionCollectionPopulator::class => $additionalDefinitionCollectionPopulatorDefinition,
+            ]];
+    }
+
+    public static function withAdditionalDefinitionCollectionPopulatorNotImplementingInterfaceProvider(): \Generator
+    {
+        $config = Yaml::parseFile(__DIR__ . '/../../Fixtures/Configuration/config_with_enabled_cache.yaml');
+
+        $additionalDefinitionCollectionPopulatorDefinition = new Definition(
+            AdditionalDefinitionCollectionPopulatorNotImplementingInterface::class
+        );
+        $additionalDefinitionCollectionPopulatorDefinition->setAutoconfigured(true);
+        $additionalDefinitionCollectionPopulatorDefinition->setPublic(false);
+
+        yield [
+            $config, [
+                AdditionalDefinitionCollectionPopulatorNotImplementingInterface::class => $additionalDefinitionCollectionPopulatorDefinition,
             ]];
     }
 
@@ -95,5 +113,26 @@ final class DefinitionProviderTest extends TestCase
         $lastEntityName = $entityNames[count($entityNames) - 1];
 
         $this->assertSame('new_entity', $lastEntityName);
+    }
+
+    /**
+     * @param ITBShopwareSdkConfiguration $config
+     * @param array<string, Definition> $dependencyInjectionDefinitions
+     */
+    #[DataProvider('withAdditionalDefinitionCollectionPopulatorNotImplementingInterfaceProvider')]
+    public function testWithAdditionalDefinitionCollectionPopulatorNotImplementingInterface(
+        array $config,
+        array $dependencyInjectionDefinitions
+    ): void {
+        $kernel = new ITBShopwareSdkBundleKernel('test', true, $config, $dependencyInjectionDefinitions);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The class %s must implement %s to be used as an entity definition collection populator. The `AsEntityDefinitionCollectionPopulator` attribute cannot be used here.',
+            AdditionalDefinitionCollectionPopulatorNotImplementingInterface::class,
+            DefinitionCollectionPopulator::class
+        ));
+
+        $kernel->boot();
     }
 }

--- a/tests/Functional/Repository/EntityRepositoryTest.php
+++ b/tests/Functional/Repository/EntityRepositoryTest.php
@@ -24,6 +24,7 @@ final class EntityRepositoryTest extends TestCase
         $config = Yaml::parseFile(__DIR__ . '/../../Fixtures/Configuration/config_with_enabled_cache.yaml');
 
         $additionalDefinitionCollectionPopulatorDefinition = new Definition(AdditionalDefinitionCollectionPopulator::class);
+        $additionalDefinitionCollectionPopulatorDefinition->setAutoconfigured(true);
         $additionalDefinitionCollectionPopulatorDefinition->setPublic(false);
 
         yield [

--- a/tests/Mock/AdditionalDefinitionCollectionPopulator.php
+++ b/tests/Mock/AdditionalDefinitionCollectionPopulator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace ITB\ShopwareSdkBundle\Tests\Mock;
 
+use ITB\ShopwareSdkBundle\Attribute\AsEntityDefinitionCollectionPopulator;
 use Vin\ShopwareSdk\Definition\DefinitionCollection;
 use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
+#[AsEntityDefinitionCollectionPopulator]
 final class AdditionalDefinitionCollectionPopulator implements DefinitionCollectionPopulator
 {
     public static function getEntityNames(string $shopwareVersion): array

--- a/tests/Mock/AdditionalDefinitionCollectionPopulatorNotImplementingInterface.php
+++ b/tests/Mock/AdditionalDefinitionCollectionPopulatorNotImplementingInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\ShopwareSdkBundle\Tests\Mock;
+
+use ITB\ShopwareSdkBundle\Attribute\AsEntityDefinitionCollectionPopulator;
+use Vin\ShopwareSdk\Definition\DefinitionCollection;
+
+#[AsEntityDefinitionCollectionPopulator]
+final class AdditionalDefinitionCollectionPopulatorNotImplementingInterface
+{
+    /**
+     * @return string[]
+     */
+    public static function getEntityNames(): array
+    {
+        return ['new_entity'];
+    }
+
+    public static function priority(): int
+    {
+        return 1;
+    }
+
+    public function populateDefinitionCollection(DefinitionCollection $definitionCollection): void
+    {
+        $definitionCollection->set(new AdditionalDefinition());
+    }
+}

--- a/tests/Mock/AdditionalDefinitionCollectionPopulatorWithException.php
+++ b/tests/Mock/AdditionalDefinitionCollectionPopulatorWithException.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace ITB\ShopwareSdkBundle\Tests\Mock;
 
+use ITB\ShopwareSdkBundle\Attribute\AsEntityDefinitionCollectionPopulator;
 use Vin\ShopwareSdk\Definition\DefinitionCollection;
 use Vin\ShopwareSdk\Definition\DefinitionCollectionPopulator;
 
+#[AsEntityDefinitionCollectionPopulator]
 final class AdditionalDefinitionCollectionPopulatorWithException implements DefinitionCollectionPopulator
 {
     public static function getEntityNames(string $shopwareVersion): array


### PR DESCRIPTION
The `EntityDefinitionCollectionPopulatorsCompilerPass` implemented an autotagging mechanism that iterated through all registered services in the DI container and tagged them if they implemented the `DefinitionCollectionPopulator` interface.

This lead to the loading of classes through reflection that were not used by the project this bundle is used in. The loading could trigger a deprecation warning if the class file contained one.

In environment like testing, these deprecation warnings could lead to failed tests or test pipelines without any developer error.